### PR TITLE
Fix static build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,16 @@ qrc_*.cpp
 Makefile
 *-build-*
 *.exp
+.qmake.stash
+
+Makefile.Debug
+Makefile.Release
+wrapper.sh
+target_wrapper.sh
+
+*/release
+plugins/*/release
+tests/*/release
 
 *.ilk
 *.lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ compiler:
 env:
 - QT_BASE=4
 - QT_BASE=5
+- QT_BASE=5 QMAKE_OPTS="CONFIG+=static staticlib"
 
 matrix:
   allow_failures:
   - compiler: clang
     env: QT_BASE=5
+  - compiler: clang
+    env: QT_BASE=5 QMAKE_OPTS="CONFIG+=static staticlib"
 
 services:
   - mysql
@@ -32,5 +35,5 @@ before_script:
 - mv tests/postgresql/PostgresqlConfig.h.travis tests/postgresql/PostgresqlConfig.h
 
 script:
-- qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" "CONFIG+=NO_QSM_FIREBIRD"
+- qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" "CONFIG+=NO_QSM_FIREBIRD" ${QMAKE_OPTS:+"$QMAKE_OPTS"}
 - make check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   POSTGRES_DRIVER_ARCHIVE: postgresql-9.3.5-1-windows-binaries.zip
 
   matrix:
-  - BUILD: Qt4.8.7-x86-msvc2010
+  - BUILD: 'Qt4.8.7-x86-msvc2010'
     QMAKE_OPTIONS: "CONFIG+=NO_QSM_POSTGRES"
     COMPILERBAT: '"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86'
     PRO_MAKE: nmake release
@@ -27,7 +27,15 @@ environment:
     QTARCHIVE1: 'qt-opensource-windows-x86-vs2010-4.8.7.exe'
     QTARCHIVE1_OPTS: '"-ir!?_14_\*" "-xr!*doc\*" "-xr!*examples\*" "-xr!*demos\*"'
 
-  - BUILD: Qt5.6.3-mingw32
+  - BUILD: 'Qt5.6.3-mingw32'
+    QTDIR: 'C:\Qt\5.6.3\mingw49_32'
+    COMPILERDIR: 'C:\Qt\Tools\mingw492_32\bin'
+    QMAKESPEC: win32-g++
+    PRO_MAKE: mingw32-make
+    PRO_CHECK: mingw32-make check
+
+  - BUILD: 'Qt5.6.3-mingw32-static'
+    QMAKE_OPTIONS: '"CONFIG+=static staticlib"'
     QTDIR: 'C:\Qt\5.6.3\mingw49_32'
     COMPILERDIR: 'C:\Qt\Tools\mingw492_32\bin'
     QMAKESPEC: win32-g++

--- a/common.pri
+++ b/common.pri
@@ -19,3 +19,7 @@ INCLUDEPATH += $$QSQLMIGRATOR_ROOT/src
     xunittest.depends = first
     QMAKE_EXTRA_TARGETS += xunittest
 }
+
+static {
+    DEFINES += _BUILDING_STATIC_LIBS
+}

--- a/example/example.pro
+++ b/example/example.pro
@@ -9,17 +9,25 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 }
 
 # depends SqliteMigrator.lib {
-CONFIG(release, debug|release): LIBS += -lSqliteMigrator
-else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord
+CONFIG(release, debug|release): LIBS += -lSqliteMigrator -lQSqlMigrator
+else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord -lQSqlMigratord
 
 INCLUDEPATH += $$QSQLMIGRATOR_ROOT/plugins
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
+}
 
 HEADERS += \
     Config.h \
@@ -31,4 +39,3 @@ SOURCES += \
     example.cpp \
     MyAppMigrator.cpp \
     M201503301340654_CreateUsers.cpp
-

--- a/plugins/FirebirdMigrator/FirebirdMigrator.h
+++ b/plugins/FirebirdMigrator/FirebirdMigrator.h
@@ -31,7 +31,7 @@
 #include <Qt>
 
 #ifndef FIREBIRDMIGRATOR_DLL_EXPORT
-#   ifdef Q_OS_WIN
+#   if defined(Q_OS_WIN) && !(defined(Q_CC_GNU) && defined(_BUILDING_STATIC_LIBS))
 #       ifdef _BUILDING_FIREBIRDMIGRATOR_DLL
 #           define FIREBIRDMIGRATOR_DLL_EXPORT __declspec(dllexport)
 #       else

--- a/plugins/MysqlMigrator/MysqlMigrator.h
+++ b/plugins/MysqlMigrator/MysqlMigrator.h
@@ -31,7 +31,7 @@
 #include <Qt>
 
 #ifndef MYSQLMIGRATOR_DLL_EXPORT
-#   ifdef Q_OS_WIN
+#   if defined(Q_OS_WIN) && !(defined(Q_CC_GNU) && defined(_BUILDING_STATIC_LIBS))
 #       ifdef _BUILDING_MYSQLMIGRATOR_DLL
 #           define MYSQLMIGRATOR_DLL_EXPORT __declspec(dllexport)
 #       else

--- a/plugins/PostgresqlMigrator/PostgresqlMigrator.h
+++ b/plugins/PostgresqlMigrator/PostgresqlMigrator.h
@@ -31,7 +31,7 @@
 #include <Qt>
 
 #ifndef POSTGRESQLMIGRATOR_DLL_EXPORT
-#   ifdef Q_OS_WIN
+#   if defined(Q_OS_WIN) && !(defined(Q_CC_GNU) && defined(_BUILDING_STATIC_LIBS))
 #       ifdef _BUILDING_POSTGRESQLMIGRATOR_DLL
 #           define POSTGRESQLMIGRATOR_DLL_EXPORT __declspec(dllexport)
 #       else

--- a/plugins/SqliteMigrator/SqliteMigrator.h
+++ b/plugins/SqliteMigrator/SqliteMigrator.h
@@ -31,7 +31,7 @@
 #include <Qt>
 
 #ifndef SQLITEMIGRATOR_DLL_EXPORT
-#   ifdef Q_OS_WIN
+#   if defined(Q_OS_WIN) && !(defined(Q_CC_GNU) && defined(_BUILDING_STATIC_LIBS))
 #       ifdef _BUILDING_SQLITEMIGRATOR_DLL
 #           define SQLITEMIGRATOR_DLL_EXPORT __declspec(dllexport)
 #       else

--- a/plugins/plugin.pri
+++ b/plugins/plugin.pri
@@ -17,17 +17,25 @@ else:CONFIG(debug, debug|release): LIBS += -lQSqlMigratord
 
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.so
+}
 
 unix:!symbian {
-	 maemo5 {
-		  target.path = /opt/usr/lib
-	 } else {
-		  target.path = /usr/lib
-	 }
-	 INSTALLS += target
+    maemo5 {
+        target.path = /opt/usr/lib
+    } else {
+        target.path = /usr/lib
+    }
+    INSTALLS += target
 }

--- a/src/config.h
+++ b/src/config.h
@@ -31,7 +31,7 @@
 #include <Qt>
 
 #ifndef QSQLMIGRATOR_DLL_EXPORT
-#   ifdef Q_OS_WIN
+#   if defined(Q_OS_WIN) && !(defined(Q_CC_GNU) && defined(_BUILDING_STATIC_LIBS))
 #       ifdef _BUILDING_QSQLMIGRATOR_DLL
 #           define QSQLMIGRATOR_DLL_EXPORT __declspec(dllexport)
 #       else

--- a/tests/api/api.pro
+++ b/tests/api/api.pro
@@ -9,17 +9,25 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 }
 
 # depends SqliteMigrator.lib {
-CONFIG(release, debug|release): LIBS += -lSqliteMigrator
-else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord
+CONFIG(release, debug|release): LIBS += -lSqliteMigrator -lQSqlMigrator
+else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord -lQSqlMigratord
 
 INCLUDEPATH += $$QSQLMIGRATOR_ROOT/plugins
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
+}
 
 SOURCES += tst_ApiTest.cpp \
          M20132201_180943_CreateCars.cpp \

--- a/tests/mysql/mysql.pro
+++ b/tests/mysql/mysql.pro
@@ -9,17 +9,25 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 }
 
 # depends MysqlMigrator.lib {
-CONFIG(release, debug|release): LIBS += -lMysqlMigrator
-else:CONFIG(debug, debug|release): LIBS += -lMysqlMigratord
+CONFIG(release, debug|release): LIBS += -lMysqlMigrator -lQSqlMigrator
+else:CONFIG(debug, debug|release): LIBS += -lMysqlMigratord -lQSqlMigratord
 
 INCLUDEPATH += $$QSQLMIGRATOR_ROOT/plugins
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/MysqlMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libMysqlMigratord.so
+}
 
 SOURCES += tst_MysqlTest.cpp \
     ../BasicTest/BasicTest.cpp

--- a/tests/postgresql/postgresql.pro
+++ b/tests/postgresql/postgresql.pro
@@ -9,17 +9,25 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 }
 
 # depends PostgresqlMigrator.lib {
-CONFIG(release, debug|release): LIBS += -lPostgresqlMigrator
-else:CONFIG(debug, debug|release): LIBS += -lPostgresqlMigratord
+CONFIG(release, debug|release): LIBS += -lPostgresqlMigrator -lQSqlMigrator
+else:CONFIG(debug, debug|release): LIBS += -lPostgresqlMigratord -lQSqlMigratord
 
 INCLUDEPATH += $$QSQLMIGRATOR_ROOT/plugins
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/PostgresqlMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libPostgresqlMigratord.so
+}
 
 SOURCES += tst_PostgresqlTest.cpp \
     ../BasicTest/BasicTest.cpp

--- a/tests/sqlite/sqlite.pro
+++ b/tests/sqlite/sqlite.pro
@@ -9,17 +9,25 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 }
 
 # depends SqliteMigrator.lib {
-CONFIG(release, debug|release): LIBS += -lSqliteMigrator
-else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord
+CONFIG(release, debug|release): LIBS += -lSqliteMigrator -lQSqlMigrator
+else:CONFIG(debug, debug|release): LIBS += -lSqliteMigratord -lQSqlMigratord
 
 INCLUDEPATH += $$QSQLMIGRATOR_ROOT/plugins
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/SqliteMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libSqliteMigratord.so
+}
 
 SOURCES += tst_SqliteTest.cpp \
          ../BasicTest/BasicTest.cpp

--- a/tests/test.pri
+++ b/tests/test.pri
@@ -18,11 +18,19 @@ else:CONFIG(debug, debug|release): LIBS += -lQSqlMigratord
 
 DEPENDPATH += $$DESTDIR
 
-win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.dll
-else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.dll
-else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.so
-else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.so
-# }
+static {
+    win32-msvc*:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.lib
+    else:win32-msvc*:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.lib
+    else:win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.a
+    else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.a
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.a
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.a
+} else {
+    win32:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigrator.dll
+    else:win32:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/QSqlMigratord.dll
+    else:unix:CONFIG(release, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigrator.so
+    else:unix:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$LIB_PATH/libQSqlMigratord.so
+}
 
 # xunittest target {
 xunittest.files =


### PR DESCRIPTION
Hi! Thank you for making this library.

I tried to build static libraries:

```
qmake "CONFIG+=static staticlib"
make -j4
```

and got errors like this:

```
cd src/ && ( test -e Makefile || /usr/lib64/qt5/bin/qmake -o Makefile /home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/src/src.pro CONFIG+=staticlib ) && make -f Makefile 
make[1]: Entering directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/src'
make -f Makefile.Release
make[2]: Entering directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/src'
make[2]: Nothing to be done for `first'.
make[2]: Leaving directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/src'
make[1]: Leaving directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/src'
cd plugins/ && ( test -e Makefile || /usr/lib64/qt5/bin/qmake -o Makefile /home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/plugins.pro CONFIG+=staticlib ) && make -f Makefile 
make[1]: Entering directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins'
cd SqliteMigrator/ && ( test -e Makefile || /usr/lib64/qt5/bin/qmake -o Makefile /home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/SqliteMigrator/SqliteMigrator.pro CONFIG+=staticlib ) && make -f Makefile 
make[2]: Entering directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/SqliteMigrator'
make -f Makefile.Release
make[3]: Entering directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/SqliteMigrator'
make[3]: *** No rule to make target `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/bin/libQSqlMigrator.so', needed by `../../bin/libSqliteMigrator.a'.  Stop.
make[3]: Leaving directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/SqliteMigrator'
make[2]: *** [release] Error 2
make[2]: Leaving directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins/SqliteMigrator'
make[1]: *** [sub-SqliteMigrator-make_first] Error 2
make[1]: Leaving directory `/home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/plugins'
make: *** [sub-plugins-make_first] Error 2
```

(caused by hardcoded .so paths)

and:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /home/victor/dev/tagberry/tagberry-qt/3rdparty/QSqlMigrator/bin/libSqliteMigrator.a(SqliteRenameColumnService.o):(.data.rel.ro._ZTVN16CommandExecution25SqliteRenameColumnServiceE[_ZTVN16CommandExecution25SqliteRenameColumnServiceE]+0x30): undefined reference to `CommandExecution::BaseSqlRenameColumnService::isValid(QSharedPointer<Commands::BaseCommand const> const&, CommandExecution::CommandExecutionContext const&) const'
```

(caused by link order)

The patch fixes these issues.